### PR TITLE
[Fixed] Unexpected messages in console

### DIFF
--- a/WebFont.py
+++ b/WebFont.py
@@ -1,8 +1,10 @@
-#coding:utf-8
+# coding:utf-8
 
-import sublime, sublime_plugin
 import json
+import sublime
+import sublime_plugin
 import webbrowser
+
 
 def is_st3():
     return sublime.version()[0] == '3'
@@ -13,24 +15,26 @@ else:
     import urllib2
 
 loc = {
-    'en_US':{
-        'cant_refresh_fonts' : u'can\'t update fonts list',
-        'cant_download_font' : u'can\'t download font',
-        'unpack_error' : u'unpacking error',
-        'go_to_fontstorage' : u'* go to fontstorage.com',
-        'update_fonts_list' : u'* update fonts list',
-        'open_on_fontstorage' : u'* download font',
-        'please_wait' : u'please wait',
-        'cant_open_website' : u'can\'t open website "%s"',
+    'en_US': {
+        'cant_refresh_fonts': u'can\'t update fonts list',
+        'cant_download_font': u'can\'t download font',
+        'unpack_error': u'unpacking error',
+        'go_to_fontstorage': u'* go to fontstorage.com',
+        'update_fonts_list': u'* update fonts list',
+        'open_on_fontstorage': u'* download font',
+        'please_wait': u'please wait',
+        'cant_open_website': u'can\'t open website "%s"',
 
-        'download_reminder':u'/* Please do not use this import in production. You could download this font from here %s */'
+        'download_reminder': u'/* Please do not use this import in production. You could download this font from here %s */'
     }
 }
 
 current_loc = loc['en_US']
 
+
 def _(id):
     return current_loc[id]
+
 
 class WebfontImportFontCommand(sublime_plugin.TextCommand):
 
@@ -53,14 +57,15 @@ class WebfontCommand(sublime_plugin.WindowCommand):
 
     def __init__(self, window):
         super(WebfontCommand, self).__init__(window)
-        print("Init Fontstorage plugin")
+        # print("Init Fontstorage plugin")
         self.font_data = self._download_font_info()
 
     def _download_font_info(self):
-        print("_download_font_info")
+        # print("_download_font_info")
         try:
             if is_st3():
-                fd = urllib.request.urlopen(self.URL, timeout=5).read().decode("utf-8")
+                fd = urllib.request.urlopen(
+                    self.URL, timeout=5).read().decode("utf-8")
                 result = json.loads(fd)
             else:
                 fd = urllib2.urlopen(self.URL, timeout=5)
@@ -78,7 +83,10 @@ class WebfontCommand(sublime_plugin.WindowCommand):
     def run(self):
         print("command start")
 
-        name_list = [ _('go_to_fontstorage'), _('update_fonts_list'), _('open_on_fontstorage')]
+        name_list = [
+            _('go_to_fontstorage'),
+            _('update_fonts_list'),
+            _('open_on_fontstorage')]
         if self.font_data is not None:
             for i in self.font_data:
                 name_list.append(i['name'])
@@ -86,7 +94,8 @@ class WebfontCommand(sublime_plugin.WindowCommand):
 
     def _insert(self, text):
         if is_st3():
-            self.window.active_view().run_command("webfont_import_font", {"text" : text })
+            self.window.active_view().run_command(
+                "webfont_import_font", {"text": text})
         else:
             view = self.window.active_view()
             edit = view.begin_edit()
@@ -95,7 +104,8 @@ class WebfontCommand(sublime_plugin.WindowCommand):
             view.end_edit(edit)
 
     def _go_to_site_selected(self, index):
-        if index < 0: return
+        if index < 0:
+            return
 
         font_url = self.font_data[index]['font_url']
         if font_url is not None:
@@ -105,12 +115,15 @@ class WebfontCommand(sublime_plugin.WindowCommand):
 
     def _show_quick_panel(self, options, done):
         if is_st3():
-            sublime.set_timeout(lambda: self.window.show_quick_panel(options, done), 10)
+            sublime.set_timeout(
+                lambda: self.window.show_quick_panel(
+                    options, done), 10)
         else:
             self.window.show_quick_panel(options, done)
 
     def _selected(self, index):
-        if index < 0: return
+        if index < 0:
+            return
         if index == 0:
             self._open_in_browser(self.SITE_URL)
         elif index == 1:
@@ -127,10 +140,10 @@ class WebfontCommand(sublime_plugin.WindowCommand):
             self._show_quick_panel(name_list, self._go_to_site_selected)
 
         else:
-            font_data = self.font_data[index-3]
+            font_data = self.font_data[index - 3]
             text = (_('download_reminder') % font_data['font_url']) + '\n' \
-                   + font_data['import'] + '\n' \
-                   + font_data['comments']
+                + font_data['import'] + '\n' \
+                + font_data['comments']
             self._insert(text)
 
     def _open_in_browser(self, url):


### PR DESCRIPTION
### 1. Behavior before pull request

I constantly get messages in Sublime Text console after different actions. Today examples:

```json
key evt: control+super+f9
command: open_file {"file": "D:\\Киролайна\\Сублим.txt"}
Init Fontstorage plugin
_download_font_info

reloading plugin EditorConfig.EditorConfig
key evt: shift+control+p
command: show_overlay {"overlay": "command_palette"}
Init Fontstorage plugin
_download_font_info

key evt: control+p
command: show_overlay {"overlay": "goto", "show_files": true}
chr evt: k (0x6b)
Init Fontstorage plugin
_download_font_info

key evt: control+'
command: show_panel {"panel": "console", "toggle": true}
Init Fontstorage plugin
_download_font_info
```

### 2. Behavior after pull request

I don't get these messages in console.

### 3. Argumentation

I do not see any benefit in printing these messages. But they interfere me navigate in console.

<!-- ### 4. Alternatives -->

Thanks.
